### PR TITLE
fix: Replace invalid hook events and types in hooks.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix hooks.json using invalid hook event `PostPluginInstall` and invalid hook type `log` causing plugin load failure ([#3](https://github.com/sanghyun-io/plan-subdivider/issues/3))
+  - Replace `PostPluginInstall` with `SessionStart` (matcher: `startup`) for rule installation
+  - Replace `type: "log"` with `type: "command"` using `echo` for plugin activation message
+
 ### Planned Features
 - Task status tracking integration
 - Plan templates library

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,22 +1,22 @@
 {
   "hooks": {
-    "PostPluginInstall": [
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/install-rules.sh\"",
+            "timeout": 30,
+            "statusMessage": "Installing plan structure rules..."
+          }
+        ]
+      },
       {
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/install-rules.sh",
-            "description": "Install plan structure rule files to .claude/rules/"
-          }
-        ]
-      }
-    ],
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "log",
-            "message": "Plan Structure Plugin active. Use /subdivide to organize complex plans."
+            "command": "echo \"Plan Structure Plugin active. Use /subdivide to organize complex plans.\""
           }
         ]
       }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -13,6 +13,7 @@
         ]
       },
       {
+        "matcher": "startup|resume",
         "hooks": [
           {
             "type": "command",

--- a/scripts/install-rules.sh
+++ b/scripts/install-rules.sh
@@ -6,11 +6,6 @@ GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-echo -e "${BLUE}  Plan Structure Plugin - Rules Installation${NC}"
-echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-echo ""
-
 # Plugin's rules directory
 PLUGIN_RULES="${CLAUDE_PLUGIN_ROOT}/rules"
 
@@ -25,14 +20,35 @@ INSTALL_MODE="${CLAUDE_PLUGIN_INSTALL_MODE:-project}"
 
 if [ "$INSTALL_MODE" = "global" ]; then
   TARGET_DIR="$GLOBAL_RULES"
-  echo -e "📦 Installing rules to: ${GREEN}~/.claude/rules${NC} (global)"
 else
   TARGET_DIR="$PROJECT_RULES"
-  echo -e "📦 Installing rules to: ${GREEN}.claude/rules${NC} (project)"
+fi
+
+# Quick check: skip if all rules already exist
+ALL_INSTALLED=true
+for rule_file in "$PLUGIN_RULES"/*.md; do
+  [ -f "$rule_file" ] || continue
+  filename=$(basename "$rule_file")
+  [ -f "$TARGET_DIR/$filename" ] || { ALL_INSTALLED=false; break; }
+done
+
+if [ "$ALL_INSTALLED" = true ]; then
+  exit 0
 fi
 
 # Create target directory
 mkdir -p "$TARGET_DIR"
+
+echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${BLUE}  Plan Structure Plugin - Rules Installation${NC}"
+echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+
+if [ "$INSTALL_MODE" = "global" ]; then
+  echo -e "📦 Installing rules to: ${GREEN}~/.claude/rules${NC} (global)"
+else
+  echo -e "📦 Installing rules to: ${GREEN}.claude/rules${NC} (project)"
+fi
 
 # Copy rule files
 INSTALLED_COUNT=0


### PR DESCRIPTION
## Summary
- Replace invalid `PostPluginInstall` hook event with `SessionStart` (matcher: `startup`) for rule file installation
- Replace invalid `type: "log"` with `type: "command"` using `echo` for plugin activation message
- Add `timeout` and `statusMessage` fields for the rule installation hook

Closes #3

## Verified Against Official Docs
- [Hooks Reference](https://code.claude.com/docs/en/hooks) — 14 valid hook events, `PostPluginInstall` not included
- [Plugins Reference](https://code.claude.com/docs/en/plugins-reference) — 3 valid hook types (`command`, `prompt`, `agent`), `log` not included

## Test plan
- [ ] Install plugin: `claude plugin install plan-subdivider --scope user`
- [ ] Verify `claude plugin list` shows plugin loaded successfully (no errors)
- [ ] Start a new session and confirm rule files are copied to `.claude/rules/`
- [ ] Verify "Plan Structure Plugin active" message appears in session context

🤖 Generated with [Claude Code](https://claude.com/claude-code)